### PR TITLE
Add Home stream provider discover category

### DIFF
--- a/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeContentFlows.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeContentFlows.kt
@@ -10,4 +10,5 @@ class HomeContentFlows(
     val topRatedContent: Flow<ImmutableList<HomeMovieItem>>,
     val actionContent: Flow<ImmutableList<HomeMovieItem>>,
     val horrorContent: Flow<ImmutableList<HomeMovieItem>>,
+    val netflixContent: Flow<ImmutableList<HomeMovieItem>>,
 )

--- a/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeContentListsImpl.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeContentListsImpl.kt
@@ -2,12 +2,13 @@ package dev.bruno.wheretowatch.features.home
 
 import com.squareup.anvil.annotations.ContributesBinding
 import dev.bruno.wheretowatch.di.AppScope
-import dev.bruno.wheretowatch.features.home.movies.PopularMap
 import dev.bruno.wheretowatch.features.home.movies.PopularMovieFlowSource
+import dev.bruno.wheretowatch.features.home.movies.StreamProviderMovieFlowSource
 import dev.bruno.wheretowatch.features.home.movies.TopRatedFlowSource
 import dev.bruno.wheretowatch.features.home.movies.TrendingMovieFlowSource
 import dev.bruno.wheretowatch.features.home.movies.UpcomingMovieFlowSource
 import dev.bruno.wheretowatch.services.discover.MovieGenre
+import dev.bruno.wheretowatch.services.discover.StreamerProvider
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.Flow
@@ -19,23 +20,25 @@ class HomeContentListsImpl @Inject constructor(
     private val trendingSource: TrendingMovieFlowSource,
     private val popularSource: PopularMovieFlowSource,
     private val upcomingSource: UpcomingMovieFlowSource,
+    private val streamSource: StreamProviderMovieFlowSource,
     private val topRatedSource: TopRatedFlowSource
 ) : HomePresenter.HomeContentLists {
 
     override val contents: HomeContentFlows
         get() = HomeContentFlows(
             trendingContent = trendingSource.flow,
-            popularContent = popularSource.flow.toContentFlow(withGenre= MovieGenre.ALL),
-            actionContent = popularSource.flow.toContentFlow(withGenre= MovieGenre.ACTION),
-            horrorContent = popularSource.flow.toContentFlow(withGenre = MovieGenre.HORROR),
+            popularContent = popularSource.flow.toContentFlow(key = MovieGenre.ALL),
+            actionContent = popularSource.flow.toContentFlow(key = MovieGenre.ACTION),
+            horrorContent = popularSource.flow.toContentFlow(key = MovieGenre.HORROR),
+            netflixContent = streamSource.flow.toContentFlow(key = StreamerProvider.NETFLIX),
             upcomingContent = upcomingSource.flow,
             topRatedContent = topRatedSource.flow,
         )
 
-    private fun Flow<PopularMap>.toContentFlow(
-        withGenre: MovieGenre
-    ): Flow<ImmutableList<HomeMovieItem>> {
-        return this.map { it.getOrDefault(withGenre, persistentListOf()) }
+    private fun <T, K> Flow<T>.toContentFlow(
+        key: K,
+    ): Flow<ImmutableList<HomeMovieItem>> where T : Map<K, ImmutableList<HomeMovieItem>> {
+        return this.map { it.getOrDefault(key, persistentListOf()) }
     }
 
     override suspend fun getContent(contentType: HomeContentType) {
@@ -46,6 +49,7 @@ class HomeContentListsImpl @Inject constructor(
             HomeContentType.TopRated -> topRatedSource.getTopRated()
             HomeContentType.Action -> popularSource.getPopular(MovieGenre.ACTION)
             HomeContentType.Horror -> popularSource.getPopular(MovieGenre.HORROR)
+            HomeContentType.Netflix -> streamSource.fetchProviderMovies(StreamerProvider.NETFLIX)
         }
     }
 }

--- a/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeContentType.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeContentType.kt
@@ -9,4 +9,5 @@ sealed interface HomeContentType {
     data object Horror : HomeContentType
     data object Upcoming : HomeContentType
     data object TopRated : HomeContentType
+    data object Netflix: HomeContentType
 }

--- a/app/src/main/java/dev/bruno/wheretowatch/features/home/HomePresenter.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/features/home/HomePresenter.kt
@@ -33,6 +33,7 @@ class HomePresenter @AssistedInject constructor(
         val horrorItems by flowContents.horrorContent.collectAsRetainedState(persistentListOf())
         val upComingItems by flowContents.upcomingContent.collectAsRetainedState(persistentListOf())
         val topRatedItems by flowContents.topRatedContent.collectAsRetainedState(persistentListOf())
+        val netflixItems by flowContents.netflixContent.collectAsRetainedState(persistentListOf())
 
         // TODO get content concurrently?
         LaunchedEffect(key1 = trendingWindow) {
@@ -44,6 +45,7 @@ class HomePresenter @AssistedInject constructor(
             homeContentLists.getContent(HomeContentType.Horror)
             homeContentLists.getContent(HomeContentType.Upcoming)
             homeContentLists.getContent(HomeContentType.TopRated)
+            homeContentLists.getContent(HomeContentType.Netflix)
         }
 
         return HomeScreen.State(
@@ -53,6 +55,7 @@ class HomePresenter @AssistedInject constructor(
             topRatedItems = topRatedItems,
             actionItems = actionItems,
             horrorItems = horrorItems,
+            netflixItems = netflixItems,
         ) { event ->
             when (event) {
                 HomeScreen.Event.OpenSettings -> navigator.goTo(SettingsScreen)

--- a/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeScreen.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/features/home/HomeScreen.kt
@@ -59,6 +59,7 @@ data object HomeScreen : Screen {
         val topRatedItems: ImmutableList<HomeMovieItem>,
         val actionItems: ImmutableList<HomeMovieItem>,
         val horrorItems: ImmutableList<HomeMovieItem>,
+        val netflixItems: ImmutableList<HomeMovieItem>,
         val onEvent: (Event) -> Unit,
     ) : CircuitUiState
 
@@ -85,6 +86,7 @@ fun HomeContent(
     val topRatedItems = state.topRatedItems
     val actionItems = state.actionItems
     val horrorItems = state.horrorItems
+    val netflixItems = state.netflixItems
 
     Scaffold(
         modifier = modifier,
@@ -233,6 +235,25 @@ fun HomeContent(
                                 choices = TrendWindow.entries,
                                 modifier = Modifier
                                     .width(IntrinsicSize.Max),
+                            )
+                        },
+                    )
+                }
+
+                item(key = "netflix Items") {
+                    HorizontalCarousel(
+                        items = netflixItems,
+                        headerTitle = "On Netflix",
+                        carouselItemContent = { item ->
+                            WhereToWatchCard(
+                                model = item,
+                                type = ImageType.Poster,
+                                title = item.title,
+                                onClick = { },
+                                modifier = Modifier
+                                    .animateItemPlacement()
+                                    .width(150.dp) // TODO make it dynamic
+                                    .aspectRatio(PortraitRatio)
                             )
                         },
                     )

--- a/app/src/main/java/dev/bruno/wheretowatch/features/home/movies/StreamProviderMovieFlowSource.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/features/home/movies/StreamProviderMovieFlowSource.kt
@@ -1,0 +1,45 @@
+package dev.bruno.wheretowatch.features.home.movies
+
+import dev.bruno.wheretowatch.features.home.HomeMovieItem
+import dev.bruno.wheretowatch.services.discover.DiscoverCategory
+import dev.bruno.wheretowatch.services.discover.DiscoverContentSupplier
+import dev.bruno.wheretowatch.services.discover.StreamerProvider
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+typealias StreamMovieMap = Map<StreamerProvider, ImmutableList<HomeMovieItem>>
+
+class StreamProviderMovieFlowSource @Inject constructor(
+    private val supplier: DiscoverContentSupplier,
+) {
+    private val providerMovie = ConcurrentHashMap<StreamerProvider, ImmutableList<HomeMovieItem>>()
+    private val state = MutableStateFlow<StreamMovieMap>(mapOf())
+    val flow: Flow<StreamMovieMap> = state.asStateFlow()
+
+    suspend fun fetchProviderMovies(provider: StreamerProvider) {
+        val streamItems = supplier.get(DiscoverCategory.Streaming(provider)).map { item ->
+            HomeMovieItem(
+                id = item.id,
+                title = item.title,
+                originalTitle = item.originalTitle,
+                popularity = item.popularity,
+                voteAverage = item.voteAverage,
+                voteCount = item.voteCount,
+                buildImgModel = item.curried()
+            )
+        }.toImmutableList()
+
+        if (!providerMovie.containsKey(provider)) {
+            // Maybe it is redundant to call `putIfAbsent` at this point
+            providerMovie.putIfAbsent(provider, streamItems)
+        }
+
+        state.update { providerMovie }
+    }
+}

--- a/app/src/main/java/dev/bruno/wheretowatch/network/api/discover/KtorDiscoverRemote.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/network/api/discover/KtorDiscoverRemote.kt
@@ -28,6 +28,7 @@ class KtorDiscoverRemote @Inject constructor(
             DiscoverCategory.TopRated -> fetchTopRatedMovies()
             is DiscoverCategory.Popular -> fetchPopularMovies(category.genre)
             is DiscoverCategory.Trending -> fetchTrendingMovies(category.trendWindow.key)
+            is DiscoverCategory.Streaming -> fetchStreamProviderMovies(category.provider.id)
         }
     }
 
@@ -93,5 +94,19 @@ class KtorDiscoverRemote @Inject constructor(
             )
 
         return httpClient.get(resource).body()
+    }
+
+    private suspend fun fetchStreamProviderMovies(providerId: String): DiscoverContentResultDto {
+        val res = MovieRequest(
+            page = 1,
+            language = "en-US", // TODO get it from preferences
+            region = "DE", // TODO get it from preferences
+            watchRegion = "DE",
+            streamProviderId = providerId,
+            sortBy = "popularity.desc",
+            voteCountGTE = 400,
+        )
+
+        return httpClient.get(res).body()
     }
 }

--- a/app/src/main/java/dev/bruno/wheretowatch/network/api/discover/MovieRequest.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/network/api/discover/MovieRequest.kt
@@ -10,6 +10,10 @@ class MovieRequest(
     val region: String,
     @SerialName("sort_by")
     val sortBy: String,
+    @SerialName("watch_region")
+    val watchRegion: String? = null,
+    @SerialName("with_watch_providers")
+    val streamProviderId: String? = null,
     @SerialName("with_genres")
     val genre: String? = null,
     @SerialName("vote_count.gte")

--- a/app/src/main/java/dev/bruno/wheretowatch/services/discover/DiscoverCategory.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/services/discover/DiscoverCategory.kt
@@ -5,6 +5,7 @@ sealed interface DiscoverCategory {
     data object Upcoming : DiscoverCategory
     data object TopRated : DiscoverCategory
     data class Trending(val trendWindow: TrendWindow) : DiscoverCategory
+    data class Streaming(val provider: StreamerProvider) : DiscoverCategory
 }
 
 enum class TrendWindow(val key: String) { DAY("day"), WEEK("week") }
@@ -31,4 +32,13 @@ enum class MovieGenre(val id: String) {
     THRILLER("53"),
     WAR("10752"),
     WESTERN("37"),
+}
+
+// TODO fetch it from watch/providers/movie to get provider's Logo
+enum class StreamerProvider(val id: String) {
+    NETFLIX(id = "8"),
+    AMAZON_PRIME(id = "9"),
+    DISNEY_PLUS(id = "337"),
+    APPLE_TV_PLUS(id = "350"),
+    WOW(id = "30"),
 }

--- a/app/src/main/java/dev/bruno/wheretowatch/services/discover/DiscoverCategory.kt
+++ b/app/src/main/java/dev/bruno/wheretowatch/services/discover/DiscoverCategory.kt
@@ -40,5 +40,4 @@ enum class StreamerProvider(val id: String) {
     AMAZON_PRIME(id = "9"),
     DISNEY_PLUS(id = "337"),
     APPLE_TV_PLUS(id = "350"),
-    WOW(id = "30"),
 }


### PR DESCRIPTION
Add stream providers: Netflix, Amazon Prime, Disney+, Apple Tv+. This adds the filter `with_watch_providers` to the movie query. As expected, this returns movies sorted by popularity (from tmbdb source) and not what is popular on each stream provider.