### PR TITLE
Configure release variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ build/
 # Local configuration file (sdk path, etc)
 local.properties
 apikey.properties
+signing.properties
+
+# Do not commit plain-text release keys
+app-release.jks
 
 # Log/OS Files
 *.log

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,10 @@ val apiKeyFile: File = rootProject.file("apikey.properties")
 val apiKeyProperties = Properties()
 apiKeyProperties.load(FileInputStream(apiKeyFile))
 
+val signingKeyFile: File = rootProject.file("signing.properties")
+val signingProperties = Properties()
+signingProperties.load(FileInputStream(signingKeyFile))
+
 android {
     namespace = "dev.bruno.wheretowatch"
     compileSdk = 34
@@ -32,12 +36,31 @@ android {
             useSupportLibrary = true
         }
 
-        buildConfigField(type = "String", name = "API_KEY", value = apiKeyProperties.getProperty("API_KEY"))
+        buildConfigField(
+            type = "String",
+            name = "API_KEY",
+            value = apiKeyProperties.getProperty("API_KEY")
+        )
+    }
+
+    signingConfigs {
+        create("release") {
+            storeFile = rootProject.file("release/app-release.jks")
+            storePassword = signingProperties.getProperty("RELEASE_STORE_PASS")
+            keyAlias = "wheretowatch"
+            keyPassword = signingProperties.getProperty("RELEASE_KEY_PASS")
+        }
     }
 
     buildTypes {
+        debug {
+            versionNameSuffix = "-dev"
+            applicationIdSuffix = ".debug"
+        }
         release {
-            isMinifyEnabled = false
+            signingConfig = signingConfigs["release"]
+            isShrinkResources = true
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -62,6 +85,9 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+    }
+    lint {
+        baseline = file("lint-baseline.xml")
     }
 }
 

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.2)" variant="fatal" version="8.1.2">
+
+    <issue
+        id="Instantiatable"
+        message="This class should provide a default constructor (a public constructor with no arguments) (`dev.bruno.wheretowatch.MainActivity`)"
+        errorLine1="            android:name=&quot;.MainActivity&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="21"
+            column="27"/>
+    </issue>
+
+</issues>

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-dontwarn org.slf4j.impl.StaticLoggerBinder


### PR DESCRIPTION
This PR introduces a signing config for the release variant to test a release APK to see how smoothly Compose runs with all the optimizations.